### PR TITLE
Fix bug while the inference result is empty with YOLOv5 (#29)

### DIFF
--- a/fastdeploy/vision/ultralytics/yolov5.cc
+++ b/fastdeploy/vision/ultralytics/yolov5.cc
@@ -202,6 +202,11 @@ bool YOLOv5::Postprocess(
       result->scores.push_back(confidence);
     }
   }
+
+  if (result->boxes.size() == 0) {
+    return  true;
+  }
+ 
   utils::NMS(result, nms_iou_threshold);
 
   // scale the boxes to the origin image shape

--- a/fastdeploy/vision/utils/sort_det_res.cc
+++ b/fastdeploy/vision/utils/sort_det_res.cc
@@ -68,7 +68,11 @@ void MergeSort(DetectionResult* result, size_t low, size_t high) {
 
 void SortDetectionResult(DetectionResult* result) {
   size_t low = 0;
-  size_t high = result->scores.size() - 1;
+  size_t high = result->scores.size();
+  if (high == 0) {
+      return;
+  }
+  high = high - 1;
   MergeSort(result, low, high);
 }
 


### PR DESCRIPTION
* Add multi-label function for yolov5

* Update README.md

Update doc

* Update fastdeploy_runtime.cc

fix variable option.trt_max_shape wrong name

* Update runtime_option.md

Update resnet model dynamic shape setting name from images to x

* Fix bug when inference result boxes are empty

* Delete detection.py